### PR TITLE
urls in a sitemap are https:// instead of https:/

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sabloger/sitemap-generator
+module github.com/sirisjo/sitemap-generator
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sirisjo/sitemap-generator
+module github.com/sabloger/sitemap-generator
 
 go 1.16

--- a/smg/sitemap.go
+++ b/smg/sitemap.go
@@ -4,7 +4,8 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"path/filepath"
+	"net/url"
+	"path"
 	"time"
 )
 
@@ -87,8 +88,12 @@ func (s *Sitemap) realAdd(u *SitemapLoc, locN int, locBytes []byte) error {
 	}
 
 	if locBytes == nil {
-		u.Loc = filepath.Join(s.Hostname, u.Loc)
-		var err error
+		output, err := url.Parse(s.Hostname)
+		if err != nil {
+			return err
+		}
+		output.Path = path.Join(output.Path, u.Loc)
+		u.Loc = output.String()
 		locN, locBytes, err = s.encodeToXML(u)
 		if err != nil {
 			return err

--- a/smg/sitemap_test.go
+++ b/smg/sitemap_test.go
@@ -1,9 +1,27 @@
 package smg
 
 import (
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 )
+
+type UrlSet struct {
+	XMLName xml.Name `xml:"urlset"`
+	Urls []UrlData `xml:"url"`
+}
+
+type UrlData struct {
+	XMLName xml.Name `xml:"url"`
+	Loc string `xml:"loc"`
+	LasMod string `xml:"lastmod"`
+	ChangeFreq string `xml:"changefreq"`
+	Priority string `xml:"priority"`
+}
+
 
 // TestSingleSitemap tests the module against Single-file sitemap usage format.
 func TestSingleSitemap(t *testing.T) {
@@ -52,4 +70,50 @@ func TestSingleSitemap(t *testing.T) {
 	// -----------------------------------------------------------------
 	// Removing the generated path and files
 	removeTmpFiles(t, path)
+}
+
+// TestSitemapAdd tests that the Add function produces a proper URL
+func TestSitemapAdd(t *testing.T) {
+	path := "./tmp/sitemap_test"
+	testLocation := "/test"
+	now := time.Now().UTC()
+	sm := NewSitemap(true)
+	sm.SetName("single_sitemap")
+	sm.SetHostname(baseURL)
+	sm.SetOutputPath(path)
+	sm.SetLastMod(&now)
+	sm.SetCompress(false)
+
+	err := sm.Add(&SitemapLoc{
+		Loc:        testLocation,
+		LastMod:    &now,
+		ChangeFreq: Always,
+		Priority:   0.4,
+	})
+	if err != nil {
+		t.Fatal("Unable to add SitemapLoc:", err)
+	}
+	expectedUrl := fmt.Sprintf("%s%s", baseURL, testLocation)
+	filepath, err := sm.Save()
+	if err != nil {
+		t.Fatal("Unable to Save Sitemap:", err)
+	}
+	xmlFile, err := os.Open(fmt.Sprintf("%s/%s",path, filepath[0]))
+	if err != nil {
+		t.Fatal("Unable to open file:", err)
+	}
+	defer xmlFile.Close()
+	byteValue, _ := ioutil.ReadAll(xmlFile)
+	var urlSet UrlSet
+	err = xml.Unmarshal(byteValue, &urlSet)
+	if err != nil {
+		t.Fatal("Unable to unmarhsall sitemap byte array into xml: ", err)
+	}
+	actualUrl := urlSet.Urls[0].Loc
+	if actualUrl != expectedUrl {
+		t.Fatal(fmt.Sprintf("URL Mismatch: \nActual: %s\nExpected: %s", actualUrl, expectedUrl))
+	}
+
+	removeTmpFiles(t, "./tmp")
+
 }


### PR DESCRIPTION
A bug in the `realAdd` function was causing sitemap URLS to be generated with only one slash in their addresses, which is not a valid URL. This change uses `path.Join` instead of `filepath.Join` to fix. Also wrote a test to check that the url is what is expected. 