### PR TITLE
urls in Sitemap Index are https:// instead of https:/

### DIFF
--- a/smg/sitemapindex.go
+++ b/smg/sitemapindex.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
+	"path"
 	"path/filepath"
 	"sync"
 	"time"
@@ -189,7 +191,13 @@ func (s *SitemapIndex) saveSitemaps() error {
 				return
 			}
 			for _, smFilename := range smFilenames {
-				sm.SitemapIndexLoc.Loc = filepath.Join(s.Hostname, s.ServerURI, smFilename)
+				output, err := url.Parse(s.Hostname)
+				if err != nil {
+					log.Println("Error parsing URL:", s.Hostname)
+					return
+				}
+				output.Path = path.Join(output.Path, s.ServerURI, smFilename)
+				sm.SitemapIndexLoc.Loc = output.String()
 				s.Add(sm.SitemapIndexLoc)
 			}
 			s.wg.Done()

--- a/smg/sitemapindex.go
+++ b/smg/sitemapindex.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"path/filepath"
 	"sync"
 	"time"
 )
@@ -177,7 +176,13 @@ func (s *SitemapIndex) Save() (string, error) {
 		return "", err
 	}
 	_, err = writeToFile(filename, s.OutputPath, s.Compress, buf.Bytes())
-	s.finalURL = filepath.Join(s.Hostname, s.OutputPath, filename)
+	output, err := url.Parse(s.Hostname)
+	if err != nil {
+		log.Println("Error parsing URL:", s.Hostname)
+		return "", err
+	}
+	output.Path = path.Join(output.Path, s.OutputPath, filename)
+	s.finalURL = output.String()
 	return filename, err
 }
 


### PR DESCRIPTION
Using the `filepath.Join` function in multiple places was causing sitemap index URLs to be generated with only one slash in their addresses, which is not a valid URL. This change uses `path.Join` instead, and also adds 2 tests to check that the url is what is expected. 