### PR TITLE
Update loc.go

### DIFF
--- a/smg/loc.go
+++ b/smg/loc.go
@@ -16,7 +16,7 @@ type SitemapLoc struct {
 
 // SitemapIndexLoc contains data related to <sitemap> tag in SitemapIndex.
 type SitemapIndexLoc struct {
-	XMLName xml.Name   `xml:"url"`
+	XMLName xml.Name   `xml:"sitemap"`
 	Loc     string     `xml:"loc"`
 	LastMod *time.Time `xml:"lastmod,omitempty"`
 }


### PR DESCRIPTION
According to the spec, the xml tag for the sitemaps should be `<sitemap>`, not `<url>` https://www.sitemaps.org/protocol.html#sitemapIndex_sitemap