### PR TITLE
fix: Sitemap loc in the SitemapIndex file is duplicated.

### DIFF
--- a/smg/sitemapindex.go
+++ b/smg/sitemapindex.go
@@ -206,8 +206,10 @@ func (s *SitemapIndex) saveSitemaps() error {
 					return
 				}
 				output.Path = path.Join(output.Path, s.ServerURI, smFilename)
-				sm.SitemapIndexLoc.Loc = output.String()
-				s.Add(sm.SitemapIndexLoc)
+				smIndexLoc := &SitemapIndexLoc{
+					Loc: output.String(),
+				}
+				s.Add(smIndexLoc)
 			}
 			s.wg.Done()
 		}(sitemap)


### PR DESCRIPTION
When there are many URLs, the sitemap index does not add all sitemap file records as expected, it just repeats the same sitemap record.

## Current:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap>
    <loc>https://www.example.com/sitemap-packages.xml</loc>
  </sitemap>
  <sitemap>
    <loc>https://www.example.com/sitemap-packages.xml</loc>
  </sitemap>
  <sitemap>
    <loc>https://www.example.com/sitemap-packages.xml</loc>
  </sitemap>
  <sitemap>
    <loc>https://www.example.com/sitemap-packages.xml</loc>
  </sitemap>
</sitemapindex>
```

## Expected:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap>
    <loc>https://www.example.com/sitemap-packages3.xml</loc>
  </sitemap>
  <sitemap>
    <loc>https://www.example.com/sitemap-packages2.xml</loc>
  </sitemap>
  <sitemap>
    <loc>https://www.example.com/sitemap-packages1.xml</loc>
  </sitemap>
  <sitemap>
    <loc>https://www.example.com/sitemap-packages.xml</loc>
  </sitemap>
</sitemapindex>
```

